### PR TITLE
モバイルのハンバーガーメニューが閉じない問題を修正

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -5,7 +5,7 @@ const barClass = '[grid-area:1/1] block h-[3px] w-[35px] rounded-[3px] bg-curren
 <nav id='site-nav' class='group' data-open='false'>
   <button
     id='nav-toggle'
-    class='z-[200] ml-2.5 grid size-[42px] cursor-pointer place-items-center text-main md:hidden'
+    class='relative z-[200] ml-2.5 grid size-[42px] cursor-pointer place-items-center text-main md:hidden'
     aria-expanded='false'
     aria-controls='nav-list'
   >


### PR DESCRIPTION
## 問題

モバイルでハンバーガーメニューを開いた後、ボタン（×）をタップしても閉じられない。

## 原因

トグルボタンに `z-[200]` を付けていたが `position` 指定が無く、`z-index` は positioned 要素にしか効かないため無効になっていた。その結果、メニューを開いたときに全画面オーバーレイの `ul`（`fixed z-[100]` = positioned）がボタンより前面に描画され、ボタンへのタップを奪っていた。

旧 Next.js 版の `.btn` には `position: relative; z-index: 200;` があったが、Tailwind 化の際に `relative` が抜け落ちていた。

## 修正

ボタンに `relative` を追加し、`z-[200]` を有効化してオーバーレイ（z-100）より前面に重ねた。

## 検証

- `npm run build` 成功
- 生成 CSS に `.relative{position:relative}` / `z-index:200`（ボタン）/ `z-index:100`（オーバーレイ）が出力されていることを確認
- 生成 HTML のボタンに `relative` クラスが付与されていることを確認

https://claude.ai/code/session_01BeLZh998WvZXkvPL9GSAxV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeLZh998WvZXkvPL9GSAxV)_