### PR TITLE
本番 URL を Cloudflare Workers のドメインに更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Astro 5（完全静的出力）+ Tailwind CSS v4 で構築した個人ポートフォリオサイト。JS フレームワークは不使用で、インタラクションはすべて素の `<script>` で実装している。作品データはリポジトリ内の Content Collections（Markdown）で管理し、Cloudflare Workers の静的アセット配信でホスティングする。
 
-**移行メモ:** 旧構成は Next.js 13 + microCMS + Vercel。`src/content/works/` の `sample-work-*.md` は microCMS からエクスポートした実データに差し替えるまでの仮データ（要 microCMS 認証情報）。Cloudflare への初回デプロイは未実施で、本番（https://kai-itakura-portfolio.vercel.app）は移行前の旧サイトが稼働中。残タスクはリポジトリの issue を参照。
+**移行メモ:** 旧構成は Next.js 13 + microCMS + Vercel。`src/content/works/` の `sample-work-*.md` は microCMS からエクスポートした実データに差し替えるまでの仮データ（要 microCMS 認証情報）。本番は Cloudflare Workers（https://portfolio.itakai199969-e42.workers.dev）で稼働中。残タスクはリポジトリの issue を参照。
 
 ## コマンド
 
@@ -42,7 +42,7 @@ npm run deploy     # ビルドして wrangler で Cloudflare にデプロイ
 - **スタイリング:** Tailwind CSS v4。設定ファイルはなく、テーマトークン（`--color-main`、`--color-accent`、`--font-pacifico` 等）は `src/styles/global.css` の `@theme` ブロックで定義。要素セレクタへのベーススタイル（body のフォント・背景、h2 の Pacifico、a の hover 等）も同ファイルの `@layer base` にある。旧 SCSS のピクセル値は `text-[80px]` のような arbitrary value でそのまま移植している
 - **ブレークポイント:** モバイル（767px 以下）のスタイルは `max-md:` プレフィックス。旧 SCSS の `mq(sp)` に対応する
 - **フォーマット（Prettier）:** セミコロンなし、シングルクォート（JSX も）、末尾カンマなし、インデント2スペース、print width 120
-- **デプロイ:** `wrangler.jsonc` で `dist/` を Cloudflare Workers の静的アセットとして配信。`astro.config.mjs` の `site` は OG/canonical/sitemap の URL に使われるため、Cloudflare の本番ドメインが決まったら更新が必要
+- **デプロイ:** `wrangler.jsonc` で `dist/` を Cloudflare Workers の静的アセットとして配信。`astro.config.mjs` の `site`（現在は workers.dev の URL）は OG/canonical/sitemap の URL に使われるため、カスタムドメインに変更する際は更新が必要
 
 ## ソース構成
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ポートフォリオサイト
 
-Astro + Tailwind CSS で構築したポートフォリオサイト（Cloudflare でのホスティングを想定。移行作業中のため、現在の本番 https://kai-itakura-portfolio.vercel.app は移行前の Next.js 版）。
+Astro + Tailwind CSS で構築したポートフォリオサイト。Cloudflare Workers でホスティング: https://portfolio.itakai199969-e42.workers.dev
 
 ![portfolioサイト](./portfolio.gif)
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
 
 export default defineConfig({
-  site: 'https://kai-itakura-portfolio.vercel.app',
+  site: 'https://portfolio.itakai199969-e42.workers.dev',
   integrations: [sitemap()],
   vite: {
     plugins: [tailwindcss()]


### PR DESCRIPTION
## 概要

本番が Cloudflare Workers（`https://portfolio.itakai199969-e42.workers.dev`）で稼働を開始したため、`astro.config.mjs` の `site` を旧 Vercel URL から workers.dev の URL に更新する。あわせてドキュメントの記載も更新。

`site` は canonical・OG・sitemap の URL 生成に使われる。

## 変更

- `astro.config.mjs`: `site` を `https://portfolio.itakai199969-e42.workers.dev` に変更
- `README.md`: 本番 URL を Cloudflare Workers のものに更新
- `CLAUDE.md`: 移行メモを「Cloudflare Workers で稼働中」に更新。`site` の注記を「カスタムドメインに変更する際は更新が必要」に修正

## 検証

`npm run build` 後、生成物が新 URL を指していることを確認:

- canonical: `https://portfolio.itakai199969-e42.workers.dev/`
- og:url / og:image: 同上
- `sitemap-0.xml` の `<loc>`: 同上

## 関連

issue #6。カスタムドメインを後日設定する場合は、その時点で `site` を再更新する（#6 は完了ではなくカスタムドメイン分を残す形でも可）。

https://claude.ai/code/session_01BeLZh998WvZXkvPL9GSAxV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeLZh998WvZXkvPL9GSAxV)_