### PR TITLE
初期表示時にハンバーガーメニューが一瞬開く現象を修正

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -47,4 +47,9 @@ const barClass = '[grid-area:1/1] block h-[3px] w-[35px] rounded-[3px] bg-curren
   document.querySelectorAll('.nav-link').forEach((link) => {
     link.addEventListener('click', () => setOpen(false))
   })
+
+  // 初回描画が終わってから transition を有効化し、ロード時に一瞬開く現象を防ぐ
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => document.documentElement.classList.add('nav-ready'))
+  })
 </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -76,6 +76,13 @@
   }
 }
 
+/* 初期ロード時にメニュー/ハンバーガーの transition が発火し（特に iOS Safari）、
+   メニューが一瞬開いて見える現象を防ぐ。Nav.astro が描画後に html.nav-ready を付与する */
+html:not(.nav-ready) #nav-list,
+html:not(.nav-ready) #nav-toggle span {
+  transition: none !important;
+}
+
 /* スクロール時のヘッダー背景（Header.astro のスクリプトから付け外しする） */
 .header-scrolled {
   background-color: rgb(58 61 62 / 0.5);


### PR DESCRIPTION
## 概要

ページの初期表示時に、モバイルのハンバーガーメニュー（オフキャンバスのパネル）が一瞬開いて見える現象を修正する。

## 原因

`Nav.astro` のメニューパネルとハンバーガーのバーに `transition-transform` が付いており、初回ロード時にこの transition が発火してオフキャンバスのパネルがスライドして見える（特に iOS Safari は初回描画時に CSS transition を再生する挙動がある）。`data-open` は `false` のままで状態自体は閉じているが、トランジションのアニメーションだけが一瞬走っていた。

## 変更内容

- `src/styles/global.css`: `html:not(.nav-ready)` の間は `#nav-list` / `#nav-toggle span` の `transition` を無効化
- `src/components/Nav.astro`: 二段 `requestAnimationFrame`（＝初回描画完了後）で `html.nav-ready` を付与し、以降のメニュー開閉は従来どおりアニメーションするようにした

## 確認

- `npm run build` 通過。CSS ガードとスクリプトが全ページに反映されることを確認済み。
- flash は iOS Safari 由来のため、実機（iPhone）での初回表示確認を推奨。

Closes #12

https://claude.ai/code/session_01ToRY8y1Q6jJ7Pcs7sWBZPD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToRY8y1Q6jJ7Pcs7sWBZPD)_